### PR TITLE
csprojのフォーマットをSDKスタイルに変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,24 +20,20 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.3.1
-
-    - name: Setup Nuget
-      uses: NuGet/setup-nuget@v1.2.0
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4.0.0
 
     - name: Restore nuget packages
-      run: nuget restore AtsExCsTemplate.sln
+      run: dotnet restore AtsExCsTemplate.sln --locked-mode
 
     - name: MSBuild
-      run: msbuild AtsExCsTemplate.sln /m /p:configuration="Release" /p:platform="Any CPU" /p:OutputPath="./out/"
-      shell: cmd
+      run: dotnet publish .\AtsExCsTemplate.sln --configuration Release --no-restore /p:platform="Any CPU" /p:OutputPath="./out/"
 
     - name: Collect artifact
       run: |
         ls -alR
         mkdir plugins/
-        find . -type f -path '*/out/*.dll' | xargs mv -t ./plugins/
+        find . -type f -path '*/out/publish/*.dll' | xargs mv -t ./plugins/
       shell: bash
 
     - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,16 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Setup MSBuild.exe
-        uses: microsoft/setup-msbuild@v1.3.1
-      - name: Setup Nuget
-        uses: NuGet/setup-nuget@v1.2.0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4.0.0
       - name: Restore nuget packages
-        run: nuget restore AtsExCsTemplate.sln
+        run: dotnet restore AtsExCsTemplate.sln --locked-mode
       - name: Build sln
-        run: msbuild AtsExCsTemplate.sln /m /p:configuration="Release" /p:platform="Any CPU" /p:OutputPath="./out/"
-        shell: cmd
+        run: dotnet publish .\AtsExCsTemplate.sln --configuration Release --no-restore /p:platform="Any CPU" /p:OutputPath="./out/"
       - name: Collect artifact
         run: |
           mkdir plugins/
-          find . -type f -path '*/out/*.dll' | xargs mv -t ./plugins/
+          find . -type f -path '*/out/publish/*.dll' | xargs mv -t ./plugins/
         shell: bash
       - name: Check assembly version
         id: version

--- a/Extension/Extension.csproj
+++ b/Extension/Extension.csproj
@@ -1,91 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{80D2BAF1-62D2-4538-8249-5F1C6D2B3DCE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>AtsExCsTemplate.Extension</RootNamespace>
-    <AssemblyName>Extension</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>false</Deterministic>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.CoreExtensions, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.CoreExtensions.0.19.0\lib\AtsEx.CoreExtensions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.PluginHost, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\AtsEx.PluginHost.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BveTypes, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\BveTypes.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastCaching, Version=0.17.30125.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastCaching.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastMember, Version=0.17.21224.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastMember.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ObjectiveHarmonyPatch, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ObjectiveHarmonyPatch.1.0.0\lib\ObjectiveHarmonyPatch.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
-      <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="TypeWrapping, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\TypeWrapping.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnembeddedResources, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnembeddedResources.1.0.0\lib\UnembeddedResources.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Extension.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/Extension/Properties/AssemblyInfo.cs
+++ b/Extension/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下を通して制御されます
 // 制御されます。アセンブリに関連付けられている情報を変更するには、
@@ -14,13 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
-// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
-// その型の ComVisible 属性を true に設定してください。
-[assembly: ComVisible(false)]
-
-// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
-[assembly: Guid("80d2baf1-62d2-4538-8249-5f1c6d2b3dce")]
 
 // アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
 //

--- a/Extension/packages.config
+++ b/Extension/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AtsEx.CoreExtensions" version="0.19.0" targetFramework="net48" />
-  <package id="AtsEx.PluginHost" version="0.19.0" targetFramework="net48" />
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
-  <package id="ObjectiveHarmonyPatch" version="1.0.0" targetFramework="net48" />
-  <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
-  <package id="UnembeddedResources" version="1.0.0" targetFramework="net48" />
-</packages>

--- a/Extension/packages.lock.json
+++ b/Extension/packages.lock.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "AtsEx.CoreExtensions": {
+        "type": "Direct",
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "dependencies": {
+          "AtsEx.PluginHost": "0.19.0",
+          "ObjectiveHarmonyPatch": "1.0.0"
+        }
+      },
+      "AtsEx.PluginHost": {
+        "type": "Transitive",
+        "resolved": "0.19.0",
+        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2",
+          "SlimDX": "4.0.13.44",
+          "UnembeddedResources": "1.0.0"
+        }
+      },
+      "Lib.Harmony": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "70KvWz+DiUELxafsYL/LHxA/jH3PDWeApLo/VwtnrpTvRWQ/eUdPfS/l5funmhZWOy41QXw6UjVv+6C57Nx77A=="
+      },
+      "ObjectiveHarmonyPatch": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "S2BGbjE+8Qt7IK/0+BTOz1h6AgeKr+CkXZMbOqf4zaTzk9YkY7CP1CRBUQshfxp+3VYnHNDya8Ka3LwNNlhUEA==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2"
+        }
+      },
+      "SlimDX": {
+        "type": "Transitive",
+        "resolved": "4.0.13.44",
+        "contentHash": "Oj8ICZ3tIGvd93s5W6wSWXckDb3payQCo4fWp7GKPwnnGck7wEHHBZwnwfJJTdNb+t+IYr4HJCu07YhZ82xrIg=="
+      },
+      "UnembeddedResources": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "cZJ8PtsQwQ4EzShUiUdKz2blvj/r6v0/Tg5+43SsWBTpHhX79P05Srtu6ypiSPgOKePnpB5D/SM5HCyoaMQN6g=="
+      }
+    }
+  }
+}

--- a/MapPlugin/MapPlugin.csproj
+++ b/MapPlugin/MapPlugin.csproj
@@ -1,91 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C7F17EA7-55CF-449F-9255-C3B1721A4DC9}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>AtsExCsTemplate.MapPlugin</RootNamespace>
-    <AssemblyName>MapPlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>false</Deterministic>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.CoreExtensions, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.CoreExtensions.0.19.0\lib\AtsEx.CoreExtensions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.PluginHost, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\AtsEx.PluginHost.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BveTypes, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\BveTypes.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastCaching, Version=0.17.30125.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastCaching.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastMember, Version=0.17.21224.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastMember.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ObjectiveHarmonyPatch, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ObjectiveHarmonyPatch.1.0.0\lib\ObjectiveHarmonyPatch.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
-      <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="TypeWrapping, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\TypeWrapping.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnembeddedResources, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnembeddedResources.1.0.0\lib\UnembeddedResources.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MapPlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/MapPlugin/Properties/AssemblyInfo.cs
+++ b/MapPlugin/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下を通して制御されます
 // 制御されます。アセンブリに関連付けられている情報を変更するには、
@@ -13,14 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
-// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
-// その型の ComVisible 属性を true に設定してください。
-[assembly: ComVisible(false)]
-
-// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
-[assembly: Guid("c7f17ea7-55cf-449f-9255-c3b1721a4dc9")]
 
 // アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
 //

--- a/MapPlugin/packages.config
+++ b/MapPlugin/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AtsEx.CoreExtensions" version="0.19.0" targetFramework="net48" />
-  <package id="AtsEx.PluginHost" version="0.19.0" targetFramework="net48" />
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
-  <package id="ObjectiveHarmonyPatch" version="1.0.0" targetFramework="net48" />
-  <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
-  <package id="UnembeddedResources" version="1.0.0" targetFramework="net48" />
-</packages>

--- a/MapPlugin/packages.lock.json
+++ b/MapPlugin/packages.lock.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "AtsEx.CoreExtensions": {
+        "type": "Direct",
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "dependencies": {
+          "AtsEx.PluginHost": "0.19.0",
+          "ObjectiveHarmonyPatch": "1.0.0"
+        }
+      },
+      "AtsEx.PluginHost": {
+        "type": "Transitive",
+        "resolved": "0.19.0",
+        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2",
+          "SlimDX": "4.0.13.44",
+          "UnembeddedResources": "1.0.0"
+        }
+      },
+      "Lib.Harmony": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "70KvWz+DiUELxafsYL/LHxA/jH3PDWeApLo/VwtnrpTvRWQ/eUdPfS/l5funmhZWOy41QXw6UjVv+6C57Nx77A=="
+      },
+      "ObjectiveHarmonyPatch": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "S2BGbjE+8Qt7IK/0+BTOz1h6AgeKr+CkXZMbOqf4zaTzk9YkY7CP1CRBUQshfxp+3VYnHNDya8Ka3LwNNlhUEA==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2"
+        }
+      },
+      "SlimDX": {
+        "type": "Transitive",
+        "resolved": "4.0.13.44",
+        "contentHash": "Oj8ICZ3tIGvd93s5W6wSWXckDb3payQCo4fWp7GKPwnnGck7wEHHBZwnwfJJTdNb+t+IYr4HJCu07YhZ82xrIg=="
+      },
+      "UnembeddedResources": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "cZJ8PtsQwQ4EzShUiUdKz2blvj/r6v0/Tg5+43SsWBTpHhX79P05Srtu6ypiSPgOKePnpB5D/SM5HCyoaMQN6g=="
+      }
+    }
+  }
+}

--- a/VehiclePlugin/Properties/AssemblyInfo.cs
+++ b/VehiclePlugin/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 // アセンブリに関する一般情報は以下を通して制御されます
 // 制御されます。アセンブリに関連付けられている情報を変更するには、
@@ -13,14 +11,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// ComVisible を false に設定すると、このアセンブリ内の型は COM コンポーネントから
-// 参照できなくなります。COM からこのアセンブリ内の型にアクセスする必要がある場合は、
-// その型の ComVisible 属性を true に設定してください。
-[assembly: ComVisible(false)]
-
-// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
-[assembly: Guid("b4c723a7-fd6a-4931-b3bf-a6635f44899b")]
 
 // アセンブリのバージョン情報は、以下の 4 つの値で構成されています:
 //

--- a/VehiclePlugin/VehiclePlugin.csproj
+++ b/VehiclePlugin/VehiclePlugin.csproj
@@ -1,91 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{B4C723A7-FD6A-4931-B3BF-A6635F44899B}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>net48</TargetFramework>
     <RootNamespace>AtsExCsTemplate.VehiclePlugin</RootNamespace>
-    <AssemblyName>VehiclePlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Deterministic>false</Deterministic>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net48\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.CoreExtensions, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.CoreExtensions.0.19.0\lib\AtsEx.CoreExtensions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AtsEx.PluginHost, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\AtsEx.PluginHost.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="BveTypes, Version=0.19.30520.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\BveTypes.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastCaching, Version=0.17.30125.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastCaching.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FastMember, Version=0.17.21224.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\FastMember.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ObjectiveHarmonyPatch, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ObjectiveHarmonyPatch.1.0.0\lib\ObjectiveHarmonyPatch.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="SlimDX, Version=4.0.13.43, Culture=neutral, PublicKeyToken=b1b0c32fd1ffe4f9, processorArchitecture=x86">
-      <HintPath>..\packages\SlimDX.4.0.13.44\lib\NET40\SlimDX.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="TypeWrapping, Version=0.17.30127.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AtsEx.PluginHost.0.19.0\lib\TypeWrapping.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnembeddedResources, Version=1.0.30529.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnembeddedResources.1.0.0\lib\UnembeddedResources.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="VehiclePlugin.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/VehiclePlugin/packages.config
+++ b/VehiclePlugin/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="AtsEx.CoreExtensions" version="0.19.0" targetFramework="net48" />
-  <package id="AtsEx.PluginHost" version="0.19.0" targetFramework="net48" />
-  <package id="Lib.Harmony" version="2.2.2" targetFramework="net48" />
-  <package id="ObjectiveHarmonyPatch" version="1.0.0" targetFramework="net48" />
-  <package id="SlimDX" version="4.0.13.44" targetFramework="net48" />
-  <package id="UnembeddedResources" version="1.0.0" targetFramework="net48" />
-</packages>

--- a/VehiclePlugin/packages.lock.json
+++ b/VehiclePlugin/packages.lock.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "dependencies": {
+    ".NETFramework,Version=v4.8": {
+      "AtsEx.CoreExtensions": {
+        "type": "Direct",
+        "requested": "[0.19.0, )",
+        "resolved": "0.19.0",
+        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "dependencies": {
+          "AtsEx.PluginHost": "0.19.0",
+          "ObjectiveHarmonyPatch": "1.0.0"
+        }
+      },
+      "AtsEx.PluginHost": {
+        "type": "Transitive",
+        "resolved": "0.19.0",
+        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2",
+          "SlimDX": "4.0.13.44",
+          "UnembeddedResources": "1.0.0"
+        }
+      },
+      "Lib.Harmony": {
+        "type": "Transitive",
+        "resolved": "2.2.2",
+        "contentHash": "70KvWz+DiUELxafsYL/LHxA/jH3PDWeApLo/VwtnrpTvRWQ/eUdPfS/l5funmhZWOy41QXw6UjVv+6C57Nx77A=="
+      },
+      "ObjectiveHarmonyPatch": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "S2BGbjE+8Qt7IK/0+BTOz1h6AgeKr+CkXZMbOqf4zaTzk9YkY7CP1CRBUQshfxp+3VYnHNDya8Ka3LwNNlhUEA==",
+        "dependencies": {
+          "Lib.Harmony": "2.2.2"
+        }
+      },
+      "SlimDX": {
+        "type": "Transitive",
+        "resolved": "4.0.13.44",
+        "contentHash": "Oj8ICZ3tIGvd93s5W6wSWXckDb3payQCo4fWp7GKPwnnGck7wEHHBZwnwfJJTdNb+t+IYr4HJCu07YhZ82xrIg=="
+      },
+      "UnembeddedResources": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "cZJ8PtsQwQ4EzShUiUdKz2blvj/r6v0/Tg5+43SsWBTpHhX79P05Srtu6ypiSPgOKePnpB5D/SM5HCyoaMQN6g=="
+      }
+    }
+  }
+}


### PR DESCRIPTION
resolves #9 

.NET Core以降、csprojにSDKスタイルというものが導入されました。
SDKスタイルなプロジェクトファイルにはデフォルトの設定を記述する必要がないため、csprojが簡潔で読みやすく・編集しやすくなります。

この修正では、プロジェクトファイルをSDKスタイルを使ったものに変更しました。
また、この修正にあわせてdotnetコマンドを使用できるようになったため、ActionsのWorkflowについてもdotnetコマンドを使ったものに書き換えています。
前のmsbuildでもビルドできますが、dotnetコマンドの方が楽です。