### PR TITLE
AtsEXを1.0.0-RC5に更新

### DIFF
--- a/Extension/Extension.csproj
+++ b/Extension/Extension.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+    <PackageReference Include="AtsEx.CoreExtensions" Version="1.0.0-rc1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="AtsEx.PluginHost" Version="1.0.0-rc5">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Extension/packages.lock.json
+++ b/Extension/packages.lock.json
@@ -4,18 +4,19 @@
     ".NETFramework,Version=v4.8": {
       "AtsEx.CoreExtensions": {
         "type": "Direct",
-        "requested": "[0.19.0, )",
-        "resolved": "0.19.0",
-        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "requested": "[1.0.0-rc1, )",
+        "resolved": "1.0.0-rc1",
+        "contentHash": "9QRYrg1YkAE2q4WsCG5uu71ONZC2xtnC1U4vqkPW4oi9xIf06r+649bVbUEwz7Qzf/a52ooK1ic8Vh3RnBA4zA==",
         "dependencies": {
-          "AtsEx.PluginHost": "0.19.0",
+          "AtsEx.PluginHost": "1.0.0-rc1",
           "ObjectiveHarmonyPatch": "1.0.0"
         }
       },
       "AtsEx.PluginHost": {
-        "type": "Transitive",
-        "resolved": "0.19.0",
-        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "type": "Direct",
+        "requested": "[1.0.0-rc5, )",
+        "resolved": "1.0.0-rc5",
+        "contentHash": "gI+u2r0EDHc36YoaxNpIJkGh+kFfXO+QO0eGAXwg0lIT6Re2kcocKZ+6Yn6E0rRVFOcpQPjlJ6XId2dWKN89Tw==",
         "dependencies": {
           "Lib.Harmony": "2.2.2",
           "SlimDX": "4.0.13.44",

--- a/MapPlugin/MapPlugin.csproj
+++ b/MapPlugin/MapPlugin.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+    <PackageReference Include="AtsEx.CoreExtensions" Version="1.0.0-rc1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="AtsEx.PluginHost" Version="1.0.0-rc5">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/MapPlugin/packages.lock.json
+++ b/MapPlugin/packages.lock.json
@@ -4,18 +4,19 @@
     ".NETFramework,Version=v4.8": {
       "AtsEx.CoreExtensions": {
         "type": "Direct",
-        "requested": "[0.19.0, )",
-        "resolved": "0.19.0",
-        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "requested": "[1.0.0-rc1, )",
+        "resolved": "1.0.0-rc1",
+        "contentHash": "9QRYrg1YkAE2q4WsCG5uu71ONZC2xtnC1U4vqkPW4oi9xIf06r+649bVbUEwz7Qzf/a52ooK1ic8Vh3RnBA4zA==",
         "dependencies": {
-          "AtsEx.PluginHost": "0.19.0",
+          "AtsEx.PluginHost": "1.0.0-rc1",
           "ObjectiveHarmonyPatch": "1.0.0"
         }
       },
       "AtsEx.PluginHost": {
-        "type": "Transitive",
-        "resolved": "0.19.0",
-        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "type": "Direct",
+        "requested": "[1.0.0-rc5, )",
+        "resolved": "1.0.0-rc5",
+        "contentHash": "gI+u2r0EDHc36YoaxNpIJkGh+kFfXO+QO0eGAXwg0lIT6Re2kcocKZ+6Yn6E0rRVFOcpQPjlJ6XId2dWKN89Tw==",
         "dependencies": {
           "Lib.Harmony": "2.2.2",
           "SlimDX": "4.0.13.44",

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 
 ## 依存環境
 
-- AtsEx.CoreExtensions (1.0.0-rc5)
-- AtsEx.PluginHost (1.0.0-rc1)
+- AtsEx.CoreExtensions (1.0.0-rc1)
+- AtsEx.PluginHost (1.0.0-rc5)
 
 間接参照を含めたすべての依存情報については、各プロジェクトのフォルダにある `packages.lock.json` をご確認ください。
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 ## 動作環境
 - [AtsEX](https://github.com/automatic9045/AtsEX)
-    - [ver1.0-RC3 - v1.0.31118.2](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.31118.2)
-- Win10 22H2
+    - [ver1.0-RC5 - v1.0.40101.1](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.40101.1) or later
+- Win10 22H2, Win11 22H2 or later
     - Visual Studio 2022
         - Microsoft Visual Studio Community 2022 (64 ビット) - Current Version 17.5.3
 - [Bve](https://bvets.net/)
@@ -26,13 +26,11 @@
 
 
 ## 依存環境
-- AtsEx.CoreExtensions (0.19.0)
-    - AtsEx.PluginHost (>= 1.0.0-rc1)
-        - Lib.Harmony (>= 2.2.2)
-        - SlimDX (>= 4.0.13.44)
-        - UnembeddedResources (>= 1.0.0)
-    - ObjectiveHarmonyPatch (>= 1.0.0)
-        - Lib.Harmony (>= 2.2.2)
+
+- AtsEx.CoreExtensions (1.0.0-rc5)
+- AtsEx.PluginHost (1.0.0-rc1)
+
+間接参照を含めたすべての依存情報については、各プロジェクトのフォルダにある `packages.lock.json` をご確認ください。
 
 
 ## 使い方

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -208,8 +208,8 @@
 
 ## 依存環境
 **Todo: 依存環境を必要に応じて変更**
-- AtsEx.CoreExtensions (1.0.0-rc5)
-- AtsEx.PluginHost (1.0.0-rc1)
+- AtsEx.CoreExtensions (1.0.0-rc1)
+- AtsEx.PluginHost (1.0.0-rc5)
 
 (開発者向け)  
 間接参照を含めたすべての依存情報については、各プロジェクトのフォルダにある `packages.lock.json` をご確認ください。

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -191,13 +191,13 @@
     - BVE Trainsim Version 5.8.7554.391 or later
     - BVE Trainsim Version 6.0.7554.619 or later
 - [AtsEX](https://github.com/automatic9045/AtsEX)
-    - [ver1.0-RC3 - v1.0.31118.2](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.31118.2) or later
+    - [ver1.0-RC5 - v1.0.40101.1](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.40101.1) or later
 
 
 ## 開発環境
 **Todo: 開発環境を必要に応じて変更**
 - [AtsEX](https://github.com/automatic9045/AtsEX)
-    - [ver1.0-RC3 - v1.0.31118.2](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.31118.2)
+    - [ver1.0-RC5 - v1.0.40101.1](https://github.com/automatic9045/AtsEX/releases/tag/v1.0.40101.1)
 - Win10 22H2
     - Visual Studio 2022
         - Microsoft Visual Studio Community 2022 (64 ビット) - Current Version 17.5.3
@@ -208,11 +208,8 @@
 
 ## 依存環境
 **Todo: 依存環境を必要に応じて変更**
-- AtsEx.CoreExtensions (0.19.0)
-    - AtsEx.PluginHost (>= 1.0.0-rc1)
-        - Lib.Harmony (>= 2.2.2)
-        - SlimDX (>= 4.0.13.44)
-        - UnembeddedResources (>= 1.0.0)
-    - ObjectiveHarmonyPatch (>= 1.0.0)
-        - Lib.Harmony (>= 2.2.2)
+- AtsEx.CoreExtensions (1.0.0-rc5)
+- AtsEx.PluginHost (1.0.0-rc1)
 
+(開発者向け)  
+間接参照を含めたすべての依存情報については、各プロジェクトのフォルダにある `packages.lock.json` をご確認ください。

--- a/VehiclePlugin/VehiclePlugin.csproj
+++ b/VehiclePlugin/VehiclePlugin.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AtsEx.CoreExtensions" Version="0.19.0">
+    <PackageReference Include="AtsEx.CoreExtensions" Version="1.0.0-rc1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="AtsEx.PluginHost" Version="1.0.0-rc5">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/VehiclePlugin/packages.lock.json
+++ b/VehiclePlugin/packages.lock.json
@@ -4,18 +4,19 @@
     ".NETFramework,Version=v4.8": {
       "AtsEx.CoreExtensions": {
         "type": "Direct",
-        "requested": "[0.19.0, )",
-        "resolved": "0.19.0",
-        "contentHash": "QH1mmux7O7gthSbE8sMGhgmUtCy4zWeJaOdMaxczy91aft5/k1Y6MvkNRWw8o28gzA7gC3vQwMc0p0fxOpbGDA==",
+        "requested": "[1.0.0-rc1, )",
+        "resolved": "1.0.0-rc1",
+        "contentHash": "9QRYrg1YkAE2q4WsCG5uu71ONZC2xtnC1U4vqkPW4oi9xIf06r+649bVbUEwz7Qzf/a52ooK1ic8Vh3RnBA4zA==",
         "dependencies": {
-          "AtsEx.PluginHost": "0.19.0",
+          "AtsEx.PluginHost": "1.0.0-rc1",
           "ObjectiveHarmonyPatch": "1.0.0"
         }
       },
       "AtsEx.PluginHost": {
-        "type": "Transitive",
-        "resolved": "0.19.0",
-        "contentHash": "yvTShEcmP1+uWh2bqQpAtjGezrSZci+SeSk2B2YzJYXhfZbRY9g0QGnGGk1Oj0e8+UsJWeyey/8g4eSk/kjHEw==",
+        "type": "Direct",
+        "requested": "[1.0.0-rc5, )",
+        "resolved": "1.0.0-rc5",
+        "contentHash": "gI+u2r0EDHc36YoaxNpIJkGh+kFfXO+QO0eGAXwg0lIT6Re2kcocKZ+6Yn6E0rRVFOcpQPjlJ6XId2dWKN89Tw==",
         "dependencies": {
           "Lib.Harmony": "2.2.2",
           "SlimDX": "4.0.13.44",


### PR DESCRIPTION
0.19.0 (beta版) を参照していることによるエラーが発生している例を見かけたため、使用するパッケージバージョンを `1.0.0-RC5` (現在の最新RC版) に更新しました。

なお、#11 の変更を含んでいるため、そちらがmergeされ次第こちらをrebase & force pushします。

---

## 相談したいこと

### 動作環境について

以下の状態で読み込みができることを確認しましたが、READMEにどう記載すべきか迷い、とりあえず何も変更していません。

- AtsEX ver1.0.0-RC5 (v1.0.40101.1)
- Windows11 (22H2)
- BVE Trainsim version 6.0.7554.619

お手元で確認頂いてそちらの環境情報を書くか、私の環境情報で書き換えてしまうか、両方書いてしまうか、どれにしましょう?

### 依存環境について

依存パッケージを更新したため、依存環境の記述も書き換える必要があります。
こちらについて、現在間接的に依存しているパッケージも記載されていますが、直接依存しているパッケージを書くだけでもいいのではないかと思っています。
関節依存まで詳しく知りたい方には、`packages.lock.json` を見るよう案内する形になるかと思います。
