### PR TITLE
Fix Release Drafter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,17 +60,6 @@ jobs:
         run: |
            git tag ${{needs.build.outputs.version}}
            git push origin ${{needs.build.outputs.version}}
-      - name: Create release draft
-        id: create-draft
-        uses: release-drafter/release-drafter@v5.12.1
-        with:
-          version: ${{needs.build.outputs.version}}
-          name: ${{needs.build.outputs.version}}
-          tag: ${{needs.build.outputs.version}}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download a build artifact
-        uses: actions/download-artifact@v3.0.2
       - name: Get repository name
         run: |
           echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_ENV
@@ -79,13 +68,14 @@ jobs:
         run: |
            cd plugins/
            zip ${{env.FILE_NAME}}.zip -r *
-      - name: Upload release asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release Draft and Upload Release Asset
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{steps.create-draft.outputs.upload_url}} 
-          asset_path: ./plugins/${{env.FILE_NAME}}.zip
-          asset_name: ${{env.FILE_NAME}}.zip
-          asset_content_type: application/zip
+           tag_name: ${{needs.build.outputs.version}}
+           name: Release ${{needs.build.outputs.version}}
+           body: TODO New Release.
+           draft: true
+           prerelease: false
+           files: |
+             ./plugins/${{env.FILE_NAME}}.zip
+             LICENSE


### PR DESCRIPTION
### Changes:

- Fixed “Input required and not supplied: upload_url” error in previous workflow.
- Replaced the previously used “upload-release-asset” action which is no longer supported.

----

Tested in my repository, see details:   
[![Create release](https://github.com/winup-zhou/MetroAts/actions/workflows/release.yml/badge.svg)](https://github.com/winup-zhou/MetroAts/actions/workflows/release.yml)
[MetroAts@b185fe9](https://github.com/winup-zhou/MetroAts/actions/runs/9335741947)